### PR TITLE
Refactor array schema and query serialization to use Buffers.

### DIFF
--- a/tiledb/rest/capnp/array.h
+++ b/tiledb/rest/capnp/array.h
@@ -135,14 +135,12 @@ std::unique_ptr<tiledb::sm::ArraySchema> array_schema_from_capnp(
 tiledb::sm::Status array_schema_serialize(
     tiledb::sm::ArraySchema* array_schema,
     tiledb::sm::SerializationType serialize_type,
-    char** serialized_string,
-    uint64_t* serialized_string_length);
+    tiledb::sm::Buffer* serialized_buffer);
 
 tiledb::sm::Status array_schema_deserialize(
     tiledb::sm::ArraySchema** array_schema,
     tiledb::sm::SerializationType serialize_type,
-    const char* serialized_string,
-    const uint64_t serialized_string_length);
+    const tiledb::sm::Buffer& serialized_buffer);
 
 }  // namespace capnp
 }  // namespace rest

--- a/tiledb/rest/capnp/query.h
+++ b/tiledb/rest/capnp/query.h
@@ -47,29 +47,24 @@ namespace capnp {
  *
  * @param query Query to serialize
  * @param serialize_type format to serialize to
- * @param serialized_string where serialziation will be stored, note this might
- * bytes
- * @param serialized_string_length
+ * @param serialized_buffer Buffer to store serialized query
  */
 tiledb::sm::Status query_serialize(
     tiledb::sm::Query* query,
     tiledb::sm::SerializationType serialize_type,
-    char** serialized_string,
-    uint64_t* serialized_string_length);
+    tiledb::sm::Buffer* serialized_buffer);
 
 /**
  * Deserialize a query
  *
  * @param query Query to deserialize into
  * @param serialize_type format to deserialize from
- * @param serialized_string where the serialziation is stored
- * @param serialized_string_length
+ * @param serialized_buffer Buffer storing serialized query
  */
 tiledb::sm::Status query_deserialize(
     tiledb::sm::Query* query,
     tiledb::sm::SerializationType serialize_type,
-    const char* serialized_string,
-    const uint64_t serialized_string_length);
+    const tiledb::sm::Buffer& serialized_buffer);
 
 }  // namespace capnp
 }  // namespace rest

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2090,16 +2090,23 @@ int tiledb_array_schema_serialize(
   if (sanity_check(ctx, array_schema) == TILEDB_ERR)
     return TILEDB_ERR;
 
+  tiledb::sm::Buffer buffer;
   auto st = tiledb::rest::capnp::array_schema_serialize(
       array_schema->array_schema_,
       (tiledb::sm::SerializationType)serialize_type,
-      serialized_string,
-      serialized_string_length);
+      &buffer);
   if (!st.ok()) {
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
   }
+
+  // TODO(ttd): This memcpy can be removed once the serialization C API
+  // consumes a tiledb_buffer_t.
+  *serialized_string = (char*)std::malloc(buffer.size());
+  *serialized_string_length = buffer.size();
+  std::memcpy(*serialized_string, buffer.data(), buffer.size());
+
   return TILEDB_OK;
 }
 
@@ -2122,11 +2129,16 @@ int tiledb_array_schema_deserialize(
     save_error(ctx, st);
     return TILEDB_OOM;
   }
+
+  // TODO(ttd): This buffer wrapper can be removed once the serialization C API
+  // consumes a tiledb_buffer_t.
+  tiledb::sm::Buffer buffer(
+      (void*)serialized_string, serialized_string_length, false);
+
   auto st = tiledb::rest::capnp::array_schema_deserialize(
       &((*array_schema)->array_schema_),
       (tiledb::sm::SerializationType)serialize_type,
-      serialized_string,
-      serialized_string_length);
+      buffer);
   if (!st.ok()) {
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -2462,16 +2474,21 @@ int tiledb_query_serialize(
   if (sanity_check(ctx, query) == TILEDB_ERR)
     return TILEDB_ERR;
 
+  tiledb::sm::Buffer buffer;
   tiledb::sm::Status st = tiledb::rest::capnp::query_serialize(
-      query->query_,
-      (tiledb::sm::SerializationType)serialize_type,
-      serialized_string,
-      serialized_string_length);
+      query->query_, (tiledb::sm::SerializationType)serialize_type, &buffer);
   if (!st.ok()) {
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
   }
+
+  // TODO(ttd): This memcpy can be removed once the serialization C API
+  // consumes a tiledb_buffer_t.
+  *serialized_string = (char*)std::malloc(buffer.size());
+  *serialized_string_length = buffer.size();
+  std::memcpy(*serialized_string, buffer.data(), buffer.size());
+
   return TILEDB_OK;
 }
 
@@ -2489,11 +2506,13 @@ int tiledb_query_deserialize(
   if (sanity_check(ctx, query) == TILEDB_ERR)
     return TILEDB_ERR;
 
+  // TODO(ttd): This buffer wrapper can be removed once the serialization C API
+  // consumes a tiledb_buffer_t.
+  tiledb::sm::Buffer buffer(
+      (void*)serialized_string, serialized_string_length, false);
+
   tiledb::sm::Status st = tiledb::rest::capnp::query_deserialize(
-      query->query_,
-      (tiledb::sm::SerializationType)serialize_type,
-      serialized_string,
-      serialized_string_length);
+      query->query_, (tiledb::sm::SerializationType)serialize_type, buffer);
   if (!st.ok()) {
     LOG_STATUS(st);
     save_error(ctx, st);


### PR DESCRIPTION
This is in preparation to use `tiledb_buffer_t` from the serialization C API.